### PR TITLE
fix: use deploy key for semantic-release to bypass branch protection

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -11,8 +11,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
-          persist-credentials: false
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare repository
         run: git fetch --unshallow --tags

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -10,7 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.ref }}
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+          persist-credentials: false
 
       - name: Prepare repository
         run: git fetch --unshallow --tags

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -10,8 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Ensure that git uses your token with write access to the repo
-          token: ${{ secrets.GH_TOKEN }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Prepare repository
         run: git fetch --unshallow --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- Use SSH deploy key for checkout in release workflow
- This allows semantic-release to push version bumps to protected master branch

## Problem
The release workflow was failing because semantic-release's `@semantic-release/git` plugin tried to push directly to the protected master branch, which requires PRs.

## Solution
- Added SSH deploy key support to the checkout step using `ssh-key: ${{ secrets.DEPLOY_KEY }}`
- The deploy key must be added to the ruleset bypass list to allow pushes to master

## Changes
- `.github/workflows/release.yml` - Added `ssh-key: ${{ secrets.DEPLOY_KEY }}` to checkout step