### PR TITLE
fix: configure git to use SSH for semantic-release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
+      - name: Configure git to use SSH
+        run: git config --global url."git@github.com:".insteadOf "https://github.com/"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- Configure git to use SSH instead of HTTPS for semantic-release push operations

## Problem
The release workflow fails because `@semantic-release/git` uses HTTPS to push, but the deploy key only works with SSH. The error was:
```
remote: error: GH013: Repository rule violations found for refs/heads/master.
- Changes must be made through a pull request.
```

## Solution
Add a step that rewrites HTTPS URLs to SSH URLs globally:
```yaml
- name: Configure git to use SSH
  run: git config --global url."git@github.com:".insteadOf "https://github.com/"
```

This makes all git operations (including semantic-release) use SSH, which works with the deploy key.